### PR TITLE
Clamped GUI Textures to fix #58

### DIFF
--- a/src/engine/menus.cpp
+++ b/src/engine/menus.cpp
@@ -269,7 +269,7 @@ void guibutton(char *name, char *action, char *icon)
 void guiimage(char *path, char *action, float *scale, int *overlaid, char *alt, char *title)
 {
 	if(!cgui) return;
-	Texture *t = textureload(path, 0, true, false);
+	Texture *t = textureload(path, 3, true, false); // Set this to clamp = 3 to use GL_CLAMP_TO_EDGE -Cyn (fixes bug #58)
 	if(t==notexture)
 	{
 		if(alt[0]) t = textureload(alt, 0, true, false);


### PR DESCRIPTION
This also fixes the top edge on the character art in the main menu bleeding over

image0054.png in "packages/crosshairs" does have a line on top, but this fixes the line below